### PR TITLE
Skip testing for the existance of pyo files on pypy

### DIFF
--- a/test/testlex.py
+++ b/test/testlex.py
@@ -14,6 +14,14 @@ import warnings
 sys.path.insert(0,"..")
 sys.tracebacklimit = 0
 
+# For pypy, we still test that calling the interpreter
+# with -O gives the correct output, but we skip testing
+# for the existance of pyo files, since we know they
+# won't be there
+test_pyo = True
+if hasattr(sys, 'pypy_version_info'):
+    test_pyo = False
+
 import ply.lex
 
 def make_pymodule_path(filename):
@@ -350,9 +358,10 @@ class LexBuildOptionTests(unittest.TestCase):
                                     "(NUMBER,3,1,0)\n"
                                     "(PLUS,'+',1,1)\n"
                                     "(NUMBER,4,1,2)\n"))
-        self.assert_(pymodule_out_exists("lextab.pyo"))
+        if test_pyo:
+            self.assert_(pymodule_out_exists("lextab.pyo"))
 
-        pymodule_out_remove("lextab.pyo")
+            pymodule_out_remove("lextab.pyo")
         p = subprocess.Popen([sys.executable,'-OO','lex_optimize.py'],
                              stdout=subprocess.PIPE)
         result = p.stdout.read()
@@ -360,7 +369,9 @@ class LexBuildOptionTests(unittest.TestCase):
                                     "(NUMBER,3,1,0)\n"
                                     "(PLUS,'+',1,1)\n"
                                     "(NUMBER,4,1,2)\n"))
-        self.assert_(pymodule_out_exists("lextab.pyo"))
+
+        if test_pyo:
+            self.assert_(pymodule_out_exists("lextab.pyo"))
         try:
             os.remove("lextab.py")
         except OSError:
@@ -402,8 +413,9 @@ class LexBuildOptionTests(unittest.TestCase):
                                     "(NUMBER,3,1,0)\n"
                                     "(PLUS,'+',1,1)\n"
                                     "(NUMBER,4,1,2)\n"))
-        self.assert_(pymodule_out_exists("opt2tab.pyo"))
-        pymodule_out_remove("opt2tab.pyo")
+        if test_pyo:
+            self.assert_(pymodule_out_exists("opt2tab.pyo"))
+            pymodule_out_remove("opt2tab.pyo")
         p = subprocess.Popen([sys.executable,'-OO','lex_optimize2.py'],
                              stdout=subprocess.PIPE)
         result = p.stdout.read()
@@ -411,7 +423,9 @@ class LexBuildOptionTests(unittest.TestCase):
                                     "(NUMBER,3,1,0)\n"
                                     "(PLUS,'+',1,1)\n"
                                     "(NUMBER,4,1,2)\n"))
-        self.assert_(pymodule_out_exists("opt2tab.pyo"))
+
+        if test_pyo:
+            self.assert_(pymodule_out_exists("opt2tab.pyo"))
         try:
             os.remove("opt2tab.py")
         except OSError:
@@ -450,8 +464,9 @@ class LexBuildOptionTests(unittest.TestCase):
                                     "(NUMBER,3,1,0)\n"
                                     "(PLUS,'+',1,1)\n"
                                     "(NUMBER,4,1,2)\n"))
-        self.assert_(pymodule_out_exists("lexdir/sub/calctab.pyo"))
-        pymodule_out_remove("lexdir/sub/calctab.pyo")
+        if test_pyo:
+            self.assert_(pymodule_out_exists("lexdir/sub/calctab.pyo"))
+            pymodule_out_remove("lexdir/sub/calctab.pyo")
         p = subprocess.Popen([sys.executable,'-OO','lex_optimize3.py'],
                              stdout=subprocess.PIPE)
         result = p.stdout.read()
@@ -459,7 +474,8 @@ class LexBuildOptionTests(unittest.TestCase):
                                     "(NUMBER,3,1,0)\n"
                                     "(PLUS,'+',1,1)\n"
                                     "(NUMBER,4,1,2)\n"))
-        self.assert_(pymodule_out_exists("lexdir/sub/calctab.pyo"))
+        if test_pyo:
+            self.assert_(pymodule_out_exists("lexdir/sub/calctab.pyo"))
         try:
             shutil.rmtree("lexdir")
         except OSError:
@@ -493,8 +509,9 @@ class LexBuildOptionTests(unittest.TestCase):
                                     "(NUMBER,3,1,0)\n"
                                     "(+,'+',1,1)\n"
                                     "(NUMBER,4,1,2)\n"))
-        self.assert_(pymodule_out_exists("aliastab.pyo"))
-        pymodule_out_remove("aliastab.pyo")
+        if test_pyo:
+            self.assert_(pymodule_out_exists("aliastab.pyo"))
+            pymodule_out_remove("aliastab.pyo")
         p = subprocess.Popen([sys.executable,'-OO','lex_opt_alias.py'],
                              stdout=subprocess.PIPE)
         result = p.stdout.read()
@@ -502,7 +519,8 @@ class LexBuildOptionTests(unittest.TestCase):
                                     "(NUMBER,3,1,0)\n"
                                     "(+,'+',1,1)\n"
                                     "(NUMBER,4,1,2)\n"))
-        self.assert_(pymodule_out_exists("aliastab.pyo"))
+        if test_pyo:
+            self.assert_(pymodule_out_exists("aliastab.pyo"))
         try:
             os.remove("aliastab.py")
         except OSError:
@@ -556,8 +574,9 @@ class LexBuildOptionTests(unittest.TestCase):
                                     "(TOK999,'TOK999:',1,47)\n"
                                     ))
 
-        self.assert_(pymodule_out_exists("manytab.pyo"))
-        pymodule_out_remove("manytab.pyo")
+        if test_pyo:
+            self.assert_(pymodule_out_exists("manytab.pyo"))
+            pymodule_out_remove("manytab.pyo")
         try:
             os.remove("manytab.py")
         except OSError:


### PR DESCRIPTION
PyPy doesn't implement the -O flag, keeping it as a dummy flag for compatibility with C python calls.

This disables the checks for the existance of .pyo files when running the test suite on pypy, which is enough for the test suite to pass (PyPy 1.9.0)