### PR TITLE
Filter out DeprecationWarnings in test suite, so 'python -3' works

### DIFF
--- a/test/testyacc.py
+++ b/test/testyacc.py
@@ -70,6 +70,7 @@ class YaccErrorWarningTests(unittest.TestCase):
         
         if sys.hexversion >= 0x3020000:
             warnings.filterwarnings('ignore',category=ResourceWarning)
+        warnings.filterwarnings('ignore',category=DeprecationWarning)
 
     def tearDown(self):
         sys.stderr = sys.__stderr__


### PR DESCRIPTION
The test suite passes with python version 2 & 3, but fails with 'python -3' due to a DeprecationWarning, which is a little surprising. This filters out DeprecationWarning so the test suite also passes when run with 'python -3'.

It should probably check for sys.py3kwarning to be completey correct.
