### PR TITLE
Fix error when path contains periods

### DIFF
--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -2602,7 +2602,7 @@ class LRGeneratedTable(LRTable):
     # -----------------------------------------------------------------------------
 
     def write_table(self,modulename,outputdir='',signature=""):
-        basemodulename = modulename.split(".")[-1]
+        basemodulename = os.path.splitext(modulename)[0]
         filename = os.path.join(outputdir,basemodulename) + ".py"
         try:
             f = open(filename,"w")


### PR DESCRIPTION
If `modulename` contains a "." symbol then `basemodulename` only gets the second part of it, so something like `/some/path/python2.7/site-packages` becomes `7/site-packages`. This patch fixes that by using `os.path.splitext` instead of `string.split`.