### PR TITLE
pass name of module in lr.write_table, not the module itself

### DIFF
--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -3417,7 +3417,7 @@ def yacc(method='LALR', debug=yaccdebug, module=None, tabmodule=tab_module, star
 
     # Write the table file if requested
     if write_tables:
-        lr.write_table(tabmodule, outputdir, signature)
+        lr.write_table(tabmodule.__name__, outputdir, signature)
 
     # Write a pickled version of the tables
     if picklefile:


### PR DESCRIPTION
I ran into an issue while using SlimIt (unmaintained library that uses ply). I'm not sure if the error is slimit's fault or ply's fault, but the stack trace looks as follows:

Traceback (most recent call last):
  File "/Users/blee/dev/src/Content/content_web/content_web/api2/extensions.py", line 1292, in upload_to_cdn
    minified = slimit.minify(rendered_output)
  File "/Users/blee/.virtualenvs/content_web/lib/python2.7/site-packages/slimit/minifier.py", line 37, in minify
    parser = Parser()
  File "/Users/blee/.virtualenvs/content_web/lib/python2.7/site-packages/slimit/parser.py", line 61, in __init__
    debug=yacc_debug, tabmodule=yacctab, start='program')
  File "/Users/blee/.virtualenvs/content_web/lib/python2.7/site-packages/ply/yacc.py", line 3420, in yacc
    lr.write_table(tabmodule, outputdir, signature)
  File "/Users/blee/.virtualenvs/content_web/lib/python2.7/site-packages/ply/yacc.py", line 2700, in write_table
    basemodulename = modulename.split('.')[-1]
AttributeError: 'module' object has no attribute 'split'

I figured that since the name of the variable was `tabmodule` in the calling body, and the name of the variable was `modulename` in the `write_tables` function, you had perhaps intended to pass the module's name, rather than the module itself, and this accounts for the error.

If this is not correct, then I'll see if I can make a fix in Slimit's code instead.
