### PR TITLE
Fix regression when tabmodule is of the form "package.module".

### DIFF
--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -66,6 +66,7 @@ import os.path
 import inspect
 import base64
 import warnings
+import importlib
 
 __version__    = '3.5'
 __tabversion__ = '3.5'
@@ -1964,7 +1965,7 @@ class LRTable(object):
             oldpath = sys.path
             sys.path = [outputdir]
             try:
-                parsetab = __import__(module)
+                parsetab = importlib.import_module(module)
             finally:
                 sys.path = oldpath
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
+import sys
 
+install_requires = []
+if sys.version_info < (2, 7):
+    install_requires.append('importlib')
+    
 setup(name = "ply",
             description="Python Lex & Yacc",
             long_description = """
@@ -27,5 +29,6 @@ It is compatible with both Python 2 and Python 3.
             classifiers = [
               'Programming Language :: Python :: 3',
               'Programming Language :: Python :: 2',
-              ]
+              ],
+            install_requires = install_requires
             )


### PR DESCRIPTION
the __import__() function returns the top level module is returned in this case (which is not what's expected).

use importlib - install for 2.6 if missing.

setuptools is now required (pip requires it anyway for sdist installs).