### PR TITLE
Catch/ignore IOError when opening picklefile for reading in yacc.yacc()

### DIFF
--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -3265,6 +3265,8 @@ def yacc(method='LALR', debug=yaccdebug, module=None, tabmodule=tab_module, star
         errorlog.warning(str(e))
     except ImportError:
         pass
+    except IOError:
+        pass
 
     if debuglog is None:
         if debug:


### PR DESCRIPTION
Should resolve #66.