### PR TITLE
MethodType doesn't have __code__ attribute, use __func__

### DIFF
--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -3161,7 +3161,7 @@ class ParserReflect(object):
             if n.startswith('p_') and n != 'p_error':
                 self.log.warning('%r not defined as a function', n)
             if ((isinstance(v, types.FunctionType) and v.__code__.co_argcount == 1) or
-                   (isinstance(v, types.MethodType) and v.__code__.co_argcount == 2)):
+                   (isinstance(v, types.MethodType) and v.__func__.__code__.co_argcount == 2)):
                 if v.__doc__:
                     try:
                         doc = v.__doc__.split(' ')


### PR DESCRIPTION
The type `MethodType` doesn't contain attribute `__code__`, this doesn't seem to fail when running on Python, but it does when running Jython. `MethodType` does contain the attribute `__func__` which returns a `FunctionType` to which you can ask for the `__code__` attribute. 

I've ran the entire test suite and all tests pass. Let me know if I can do anything to make this PR get accepted faster, this is a blocker for my use case.

```python
Python 2.7.9 (default, Dec 10 2014, 12:28:03) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import inspect
>>> import types
>>> hasattr(types.FunctionType, '__code__')
True
>>> hasattr(types.MethodType, '__code__')
False
```