### PR TITLE
Check for existence of pickled parse tables

### DIFF
--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -1982,6 +1982,9 @@ class LRTable(object):
             import cPickle as pickle
         except ImportError:
             import pickle
+        
+        if not os.path.exists(filename):
+          raise ImportError
 
         in_f = open(filename, 'rb')
 


### PR DESCRIPTION
Fixed bug where pickled parse tables were being read regardless of whether or not they exist.