### PR TITLE
Allow decorating production functions.

### DIFF
--- a/doc/ply.html
+++ b/doc/ply.html
@@ -3167,6 +3167,42 @@ in the same source file.
 </li>
 </p>
 
+<p>
+<li>Decorators of production rules have to update the wrapped function's line number.  <tt>wrapper.co_firstlineno = func.__code__.co_firstlineno</tt>:
+
+<blockquote>
+<pre>
+from functools import wraps
+from nodes import Collection
+
+
+def strict(*types):
+    def decorate(func):
+        @wraps(func)
+        def wrapper(p):
+            func(p)
+            if not isinstance(p[0], types):
+                raise TypeError
+
+        wrapper.co_firstlineno = func.__code__.co_firstlineno
+        return wrapper
+
+    return decorate
+
+@strict(Collection)
+def p_collection(p):
+    """
+    collection  : sequence
+                | map
+    """
+    p[0] = p[1]
+</pre>
+</blockquote>
+
+</li>
+</p>
+
+
 </ul>
 </p>
 

--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -3107,7 +3107,7 @@ class ParserReflect(object):
             if not name.startswith('p_') or name == 'p_error':
                 continue
             if isinstance(item, (types.FunctionType, types.MethodType)):
-                line = item.__code__.co_firstlineno
+                line = getattr(item, 'co_firstlineno', item.__code__.co_firstlineno)
                 module = inspect.getmodule(item)
                 p_functions.append((line, module, name, item.__doc__))
 


### PR DESCRIPTION
ref: #86 

- [x] check if function has attr `co_firstlineno` before setting lineno (set manually in decorator)
- [x] added a quick line in the documentation


**Summary pasted from related issue**

> My solution is to manually add that line number to an attribute on the wrapping function, and then  `yacc` checks for that attribute before setting the line number.
> 
> An example of manually setting the attribute:
> 
> ```python
> from functools import wraps
> 
> def type_check(func):
>     @wraps(func)
>     def wrapper(p):
>         func(p)
>         #  if p[0] not int ... raise error ...
>     wrapper.co_firstlineno = func.__code__.co_firstlineno
>     return wrapper
> ```
> 
> Then that one line in the `yacc` library simply becomes: 
> 
> ```python
> line = getattr(item, 'co_firstlineno', item.__code__.co_firstlineno)
> ```
> 
> and everything else works!