### PR TITLE
use literal set notation for 2.6 compatibility

### DIFF
--- a/ply/lex.py
+++ b/ply/lex.py
@@ -179,7 +179,7 @@ class Lexer:
         with open(filename, 'w') as tf:
             tf.write('# %s.py. This file automatically created by PLY (version %s). Don\'t edit!\n' % (basetabmodule, __version__))
             tf.write('_tabversion   = %s\n' % repr(__tabversion__))
-            tf.write('_lextokens    = %s\n' % repr(self.lextokens))
+            tf.write('_lextokens    = set(%s)\n' % repr(tuple(self.lextokens)))
             tf.write('_lexreflags   = %s\n' % repr(self.lexreflags))
             tf.write('_lexliterals  = %s\n' % repr(self.lexliterals))
             tf.write('_lexstateinfo = %s\n' % repr(self.lexstateinfo))


### PR DESCRIPTION
this is for the ply optimize flag.  it creates the set as `set(('A', 'B', 'C'))` instead of `'{'A', 'B', 'C'}` used in newer python versions.