### PR TITLE
Bump version number

### DIFF
--- a/ply/__init__.py
+++ b/ply/__init__.py
@@ -1,5 +1,5 @@
 # PLY package
 # Author: David Beazley (dave@dabeaz.com)
 
-__version__ = '3.7'
+__version__ = '3.8'
 __all__ = ['lex','yacc']


### PR DESCRIPTION
Was hacking around with `pip.commands.install`, and happened to be using `ply` as a test package. Wondered why the version wasn't right!

BTW: If you want to change the version in only one place, you can use this pattern:

#### setup.py
```
from itertools import imap, ifilter
from ast import parse
from pip import __file__ as pip_loc

get_vals = lambda var0, var1: imap(lambda buf: next(imap(lambda e: e.value.s, parse(buf).body)),
                                       ifilter(lambda line: line.startswith(var0) or line.startswith(var1), f))

with open(path.join(package_name, '__init__.py')) as f:
    __author__, __version__ = get_vals('__version__', '__author__')
```

Here's one of my examples: https://github.com/SamuelMarks/python-package-gen/blob/master/setup.py