### PR TITLE
Switch print to print() as per PEP 3105

### DIFF
--- a/example/yply/ylex.py
+++ b/example/yply/ylex.py
@@ -109,8 +109,8 @@ def t_code_error(t):
 
 
 def t_error(t):
-    print "%d: Illegal character '%s'" % (t.lexer.lineno, t.value[0])
-    print t.value
+    print("%d: Illegal character '%s'" % (t.lexer.lineno, t.value[0]))
+    print(t.value)
     t.lexer.skip(1)
 
 lex.lex()

--- a/example/yply/yparse.py
+++ b/example/yply/yparse.py
@@ -22,18 +22,18 @@ def p_defsection(p):
     '''defsection : definitions SECTION
                   | SECTION'''
     p.lexer.lastsection = 1
-    print "tokens = ", repr(tokenlist)
-    print
-    print "precedence = ", repr(preclist)
-    print
-    print "# -------------- RULES ----------------"
-    print
+    print("tokens = ", repr(tokenlist))
+    print()
+    print("precedence = ", repr(preclist))
+    print()
+    print("# -------------- RULES ----------------")
+    print()
 
 
 def p_rulesection(p):
     '''rulesection : rules SECTION'''
 
-    print "# -------------- RULES END ----------------"
+    print("# -------------- RULES END ----------------")
     print_code(p[2], 0)
 
 
@@ -49,7 +49,7 @@ def p_definition_literal(p):
 
 def p_definition_start(p):
     '''definition : START ID'''
-    print "start = '%s'" % p[2]
+    print("start = '%s'" % p[2])
 
 
 def p_definition_token(p):
@@ -138,7 +138,7 @@ def p_rules(p):
     rulecount = 1
     for r in rule[1]:
         # r contains one of the rule possibilities
-        print "def p_%s_%d(p):" % (rulename, rulecount)
+        print("def p_%s_%d(p):" % (rulename, rulecount))
         prod = []
         prodcode = ""
         for i in range(len(r)):
@@ -155,17 +155,17 @@ def p_rules(p):
                     embed_count += 1
             else:
                 prod.append(item)
-        print "    '''%s : %s'''" % (rulename, " ".join(prod))
+        print("    '''%s : %s'''" % (rulename, " ".join(prod)))
         # Emit code
         print_code(prodcode, 4)
-        print
+        print()
         rulecount += 1
 
     for e, code in embedded:
-        print "def p_%s(p):" % e
-        print "    '''%s : '''" % e
+        print("def p_%s(p):" % e)
+        print("    '''%s : '''" % e)
         print_code(code, 4)
-        print
+        print()
 
 
 def p_rule(p):
@@ -204,7 +204,7 @@ def p_morerules(p):
         p[0] = p[1]
         p[0].append(p[3])
 
-#   print "morerules", len(p), p[0]
+#   print("morerules", len(p), p[0])
 
 
 def p_rulelist(p):
@@ -241,4 +241,4 @@ def print_code(code, indent):
         return
     codelines = code.splitlines()
     for c in codelines:
-        print "%s# %s" % (" " * indent, c)
+        print("%s# %s" % (" " * indent, c))

--- a/example/yply/yply.py
+++ b/example/yply/yply.py
@@ -29,14 +29,14 @@ import yparse
 from ply import *
 
 if len(sys.argv) == 1:
-    print "usage : yply.py [-nocode] inputfile"
+    print("usage : yply.py [-nocode] inputfile")
     raise SystemExit
 
 if len(sys.argv) == 3:
     if sys.argv[1] == '-nocode':
         yparse.emit_code = 0
     else:
-        print "Unknown option '%s'" % sys.argv[1]
+        print("Unknown option '%s'" % sys.argv[1])
         raise SystemExit
     filename = sys.argv[2]
 else:
@@ -44,8 +44,8 @@ else:
 
 yacc.parse(open(filename).read())
 
-print """
+print("""
 if __name__ == '__main__':
     from ply import *
     yacc.yacc()
-"""
+""")


### PR DESCRIPTION
Hi, I am new to Python and parsing, but very curious about it. I tried to use yply example, but it didn't work due to Python 2.x print syntax. I think Python 3.x print() syntax also work in recent Python 2.x versions. Please let me know if I missed something, and print syntax is fine as-is. I am using current stable Python 3.5.2 on Windows.