### PR TITLE
Fixes for problems reported by pyflakes3

### DIFF
--- a/ply/lex.py
+++ b/ply/lex.py
@@ -531,7 +531,6 @@ def _form_master_re(relist, reflags, ldict, toknames):
 # calling this with s = "t_foo_bar_SPAM" might return (('foo','bar'),'SPAM')
 # -----------------------------------------------------------------------------
 def _statetoken(s, names):
-    nonstate = 1
     parts = s.split('_')
     for i, part in enumerate(parts[1:], 1):
         if part not in names and part != 'ANY':
@@ -949,8 +948,6 @@ def lex(module=None, object=None, debug=False, optimize=False, lextab='lextab',
 
         # Add rules defined by functions first
         for fname, f in linfo.funcsym[state]:
-            line = f.__code__.co_firstlineno
-            file = f.__code__.co_filename
             regex_list.append('(?P<%s>%s)' % (fname, _get_regex(f)))
             if debug:
                 debuglog.info("lex: Adding rule %s -> '%s' (state '%s')", fname, _get_regex(f), state)

--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -64,7 +64,6 @@ import types
 import sys
 import os.path
 import inspect
-import base64
 import warnings
 
 __version__    = '3.10'
@@ -1360,7 +1359,7 @@ class Production(object):
         p = LRItem(self, n)
         # Precompute the list of productions immediately following.
         try:
-            p.lr_after = Prodnames[p.prod[n+1]]
+            p.lr_after = self.Prodnames[p.prod[n+1]]
         except (IndexError, KeyError):
             p.lr_after = []
         try:
@@ -2301,7 +2300,6 @@ class LRGeneratedTable(LRTable):
     # -----------------------------------------------------------------------------
 
     def dr_relation(self, C, trans, nullable):
-        dr_set = {}
         state, N = trans
         terms = []
 


### PR DESCRIPTION

While checking my code, pyflakes3 reported some problems in your yacc.py file too. Below is the list problems reported by pyflakes3 for current master, in the 'ply' sub-tree:
```` text
ply/lex.py:534: local variable 'nonstate' is assigned to but never used
ply/lex.py:952: local variable 'line' is assigned to but never used
ply/lex.py:953: local variable 'file' is assigned to but never used
ply/yacc.py:67: 'base64' imported but unused
ply/yacc.py:97: undefined name 'basestring'
ply/yacc.py:1363: undefined name 'Prodnames'
ply/yacc.py:2304: local variable 'dr_set' is assigned to but never used
ply/yacc.py:2838: local variable 'e' is assigned to but never used
ply/cpp.py:16: undefined name 'unicode'
````
This patch addresses all but the following reports (line numbers are in the patched version)
```` text
ply/yacc.py:96: undefined name 'basestring'
ply/yacc.py:2836: local variable 'e' is assigned to but never used
ply/cpp.py:16: undefined name 'unicode'
````
The 'basestring' is needed for Python2, 'e' seems to involve killing the entire 'try/except' block, which seems a bit drastic without consulting you, and 'unicode' is again Python2 compatibility.

The other parts of the code-base throw a lot more reports, but it's mostly test-files.

I hope it is useful, and big thanks for the great ply package!