### PR TITLE
Clear table modules from cache when overwriting

### DIFF
--- a/ply/lex.py
+++ b/ply/lex.py
@@ -1041,6 +1041,8 @@ def lex(module=None, object=None, debug=False, optimize=False, lextab='lextab',
             outputdir = os.path.dirname(srcfile)
         try:
             lexobj.writetab(lextab, outputdir)
+            if lextab in sys.modules:
+                del sys.modules[lextab]
         except IOError as e:
             errorlog.warning("Couldn't write lextab module %r. %s" % (lextab, e))
 

--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -3476,6 +3476,8 @@ def yacc(method='LALR', debug=yaccdebug, module=None, tabmodule=tab_module, star
     if write_tables:
         try:
             lr.write_table(tabmodule, outputdir, signature)
+            if tabmodule in sys.modules:
+                del sys.modules[tabmodule]
         except IOError as e:
             errorlog.warning("Couldn't create %r. %s" % (tabmodule, e))
 


### PR DESCRIPTION
I've noticed that, if one instantiates the same parser many times in the same Python process, it will print "Generating LALR tables" many times if the parser has changed. This also takes a long time, since it is repeatedly rebuilding the parse tables and writing them out to disk.

This PR fixes that by deleting the cached module with an incorrect signature out of `sys.modules`, when present. I also made a parallel change for lexers, when the `lextab` option is used.