### PR TITLE
Fix issue #31 on python3

### DIFF
--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -3070,7 +3070,7 @@ class ParserReflect(object):
             self.error = True
             return
 
-        self.tokens = tokens
+        self.tokens = sorted(tokens)
 
     # Validate the tokens
     def validate_tokens(self):


### PR DESCRIPTION
Under python 3.x the signature generation to check
for changes was failing due to changes in hash functions.
Ensures always the same signature by enforcing token order.
