### PR TITLE
Fix the find_column example in the documentation

### DIFF
--- a/doc/ply.html
+++ b/doc/ply.html
@@ -558,15 +558,12 @@ column information as a separate step.   For instance, just count backwards unti
 
 <blockquote>
 <pre>
-# Compute column. 
+# Compute column.
 #     input is the input text string
 #     token is a token instance
 def find_column(input, token):
-    last_cr = input.rfind('\n', 0, token.lexpos)
-    if last_cr < 0:
-	last_cr = 0
-    column = (token.lexpos - last_cr) + 1
-    return column
+    line_start = input.rfind('\n', 0, token.lexpos) + 1
+    return (token.lexpos - line_start) + 1
 </pre>
 </blockquote>
 


### PR DESCRIPTION
The `find_column` example returns the column off by +1 for every line but the first.

This is a simplified version of it that works by calculating the 0-based index of the first character in the line, and than calculating the difference between it and the token position + 1.