### PR TITLE
Make order of _lextokens deterministic in generated files

### DIFF
--- a/ply/lex.py
+++ b/ply/lex.py
@@ -179,7 +179,7 @@ class Lexer:
         with open(filename, 'w') as tf:
             tf.write('# %s.py. This file automatically created by PLY (version %s). Don\'t edit!\n' % (basetabmodule, __version__))
             tf.write('_tabversion   = %s\n' % repr(__tabversion__))
-            tf.write('_lextokens    = set(%s)\n' % repr(tuple(self.lextokens)))
+            tf.write('_lextokens    = set(%s)\n' % repr(tuple(sorted(self.lextokens))))
             tf.write('_lexreflags   = %s\n' % repr(self.lexreflags))
             tf.write('_lexliterals  = %s\n' % repr(self.lexliterals))
             tf.write('_lexstateinfo = %s\n' % repr(self.lexstateinfo))


### PR DESCRIPTION
For the Astropy project we include the generated lex/parser files in our repository - but every time the files are regenerated the ``_lextokens`` line changes, which makes it harder to spot real changes. This trivial PR ensures that the order of the tokens in the set is always alphabetical.