### PR TITLE
Fix Python 3.6 bug with re module flags

### DIFF
--- a/ply/lex.py
+++ b/ply/lex.py
@@ -180,7 +180,7 @@ class Lexer:
             tf.write('# %s.py. This file automatically created by PLY (version %s). Don\'t edit!\n' % (basetabmodule, __version__))
             tf.write('_tabversion   = %s\n' % repr(__tabversion__))
             tf.write('_lextokens    = set(%s)\n' % repr(tuple(self.lextokens)))
-            tf.write('_lexreflags   = %s\n' % repr(self.lexreflags))
+            tf.write('_lexreflags   = %s\n' % repr(int(self.lexreflags)))
             tf.write('_lexliterals  = %s\n' % repr(self.lexliterals))
             tf.write('_lexstateinfo = %s\n' % repr(self.lexstateinfo))
 

--- a/test/lex_optimize4.py
+++ b/test/lex_optimize4.py
@@ -1,0 +1,26 @@
+# -----------------------------------------------------------------------------
+# lex_optimize4.py
+# -----------------------------------------------------------------------------
+import re
+import sys
+
+if ".." not in sys.path: sys.path.insert(0,"..")
+import ply.lex as lex
+
+tokens = [
+    "PLUS",
+    "MINUS",
+    "NUMBER",
+    ]
+
+t_PLUS = r'\+?'
+t_MINUS = r'-'
+t_NUMBER = r'(\d+)'
+
+def t_error(t):
+    pass
+
+
+# Build the lexer
+lex.lex(optimize=True, lextab="opt4tab", reflags=re.UNICODE)
+lex.runmain(data="3+4")

--- a/test/testlex.py
+++ b/test/testlex.py
@@ -514,6 +514,26 @@ class LexBuildOptionTests(unittest.TestCase):
         except OSError:
             pass
 
+    def test_lex_optimize4(self):
+
+        # Regression test to make sure that reflags works correctly
+        # on Python 3.
+
+        for extension in ['py', 'pyc']:
+            try:
+                os.remove("opt4tab.{0}".format(extension))
+            except OSError:
+                pass
+
+        run_import("lex_optimize4")
+        run_import("lex_optimize4")
+
+        for extension in ['py', 'pyc']:
+            try:
+                os.remove("opt4tab.{0}".format(extension))
+            except OSError:
+                pass
+
     def test_lex_opt_alias(self):
         try:
             os.remove("aliastab.py")


### PR DESCRIPTION
In Python 3.6, re module flags are RegexFlags instances, not integers. This leads to an issue when setting e.g. ``reflags=re.UNICODE`` which used to work in Python 2. This PR adds a regression test to illustrate the failure:

```
======================================================================
ERROR: test_lex_optimize4 (__main__.LexBuildOptionTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tom/tmp/ply/test/opt4tab.py", line 4
    _lexreflags   = <RegexFlag.UNICODE: 32>
                    ^
SyntaxError: invalid syntax

----------------------------------------------------------------------
Ran 44 tests in 1.129s

FAILED (errors=1)
```

And I'll push a fix once I confirm that Travis fails.