### PR TITLE
Also catch PermissionError on Python3

### DIFF
--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -94,6 +94,7 @@ pickle_protocol = 0            # Protocol to use when writing pickle files
 # String type-checking compatibility
 if sys.version_info[0] < 3:
     string_types = basestring
+    PermissionError = IOError
 else:
     string_types = str
 
@@ -3308,7 +3309,7 @@ def yacc(method='LALR', debug=yaccdebug, module=None, tabmodule=tab_module, star
         if debug:
             try:
                 debuglog = PlyLogger(open(os.path.join(outputdir, debugfile), 'w'))
-            except IOError as e:
+            except (IOError, PermissionError) as e:
                 errorlog.warning("Couldn't open %r. %s" % (debugfile, e))
                 debuglog = NullLogger()
         else:


### PR DESCRIPTION
Fixes `PermissionError: [Errno 13] Permission denied: 'parser.out'` errors on Python3 if the dist-packages folder is read-only.