### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,13 @@ It is compatible with both Python 2 and Python 3.
             packages = ['ply'],
             python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
             classifiers = [
-              'Programming Language :: Python :: 3',
               'Programming Language :: Python :: 2',
+              'Programming Language :: Python :: 2.6',
+              'Programming Language :: Python :: 3',
+              'Programming Language :: Python :: 3.3',
+              'Programming Language :: Python :: 3.4',
+              'Programming Language :: Python :: 3.5',
+              'Programming Language :: Python :: 3.6',
+              'Programming Language :: Python :: 3.7',
               ]
             )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ It is compatible with both Python 2 and Python 3.
             maintainer_email = "dave@dabeaz.com",
             url = "http://www.dabeaz.com/ply/",
             packages = ['ply'],
+            python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
             classifiers = [
               'Programming Language :: Python :: 3',
               'Programming Language :: Python :: 2',


### PR DESCRIPTION
This helps pip install the correct version of the package depending on the user's Python version. 

See https://packaging.python.org/guides/dropping-older-python-versions/ for more info

Also updates Trove classifiers to make PyPI listings clearer.