### PR TITLE
Reinitialize lexing state on clone

### DIFF
--- a/ply/lex.py
+++ b/ply/lex.py
@@ -144,6 +144,10 @@ class Lexer:
             for key, ef in self.lexstateerrorf.items():
                 c.lexstateerrorf[key] = getattr(object, ef.__name__)
             c.lexmodule = object
+
+            # bind the lexing state with items from the new object
+            c.begin(self.lexstate)
+
         return c
 
     # ------------------------------------------------------------


### PR DESCRIPTION
- If this isn't done, then lexre could potentially retain references to the lexer object

The documentation seems to imply this is intended:

```
Special considerations need to be made when cloning lexers that also
maintain their own internal state using classes or closures.  Namely,
you need to be aware that the newly created lexers will share all of
this state with the original lexer.  For example, if you defined a
lexer as a class and did this::

    m = MyLexer()
    a = lex.lex(object=m)      # Create a lexer
    
    b = a.clone()              # Clone the lexer

Then both ``a`` and ``b`` are going to be bound to the same object
``m`` and any changes to ``m`` will be reflected in both lexers.  It's
important to emphasize that ``clone()`` is only meant to create a new
lexer that reuses the regular expressions and environment of another
lexer.  If you need to make a totally new copy of a lexer, then call
``lex()`` again.
```

... but that seems silly. The logic in `clone()` tries to fix all of the state of the cloned lexer, with my fix then the caveat in your documentation is no longer necessary and all the references to the old object are gone. 