### PR TITLE
Minor cleanup (dead code and broken test import)

### DIFF
--- a/ply/yacc.py
+++ b/ply/yacc.py
@@ -661,22 +661,6 @@ class Production(object):
     def __getitem__(self, index):
         return self.prod[index]
 
-    # Return the nth lr_item from the production (or None if at the end)
-    def lr_item(self, n):
-        if n > len(self.prod):
-            return None
-        p = LRItem(self, n)
-        # Precompute the list of productions immediately following.
-        try:
-            p.lr_after = self.Prodnames[p.prod[n+1]]
-        except (IndexError, KeyError):
-            p.lr_after = []
-        try:
-            p.lr_before = p.prod[n-1]
-        except IndexError:
-            p.lr_before = None
-        return p
-
     # Bind the production function name to a callable
     def bind(self, pdict):
         if self.func:

--- a/test/testcpp.py
+++ b/test/testcpp.py
@@ -10,7 +10,7 @@ if ".." not in sys.path:
     sys.path.insert(0, "..")
 
 from ply.lex import lex
-from ply.cpp import *
+from example.cpp.cpp import *
 
 
 def preprocessing(in_, out_queue):


### PR DESCRIPTION
Here are fixes for two issues I noticed (can split them apart if you want):

1. `lr_item` appears to be an unused method (`lr_item` is not referenced anywhere else in the repo). The PR just removes it. The method accesses `self.Prodnames` which is never set which reinforces the point that the method is never used.
2. Change the path for importing from cpp.py. I just noticed this because I wanted to be sure that all the tests passed after removing `lr_item` in 1.

I was updating dependencies for an old project and noticed that ply had not been updated in a while and that the suggestion was to vendor ply. After vendoring ply, `pylint --errors-only` on the project flagged the `lr_item` issue (that was all it flagged).