### PR TITLE
Remove broken method and update readme

### DIFF
--- a/src/ply/yacc.py
+++ b/src/ply/yacc.py
@@ -661,22 +661,6 @@ class Production(object):
     def __getitem__(self, index):
         return self.prod[index]
 
-    # Return the nth lr_item from the production (or None if at the end)
-    def lr_item(self, n):
-        if n > len(self.prod):
-            return None
-        p = LRItem(self, n)
-        # Precompute the list of productions immediately following.
-        try:
-            p.lr_after = self.Prodnames[p.prod[n+1]]
-        except (IndexError, KeyError):
-            p.lr_after = []
-        try:
-            p.lr_before = p.prod[n-1]
-        except IndexError:
-            p.lr_before = None
-        return p
-
     # Bind the production function name to a callable
     def bind(self, pdict):
         if self.func:

--- a/tests/README
+++ b/tests/README
@@ -3,6 +3,5 @@ conditions.  To run:
 
   $ python testlex.py 
   $ python testyacc.py 
-  $ python testcpp.py
 
 The script 'cleanup.sh' cleans up this directory to its original state.


### PR DESCRIPTION
This is a redo of #267. When #267 was closed, I saw the notice in 818ab0684e33f5f513fc839673ff56ea330b6380 and thought that the PR was closed just as part of closing everything out and retiring the project which was understandable. I came back to reference to the notice now though and saw that it was changed to https://github.com/dabeaz/ply/blob/66369a66fa85981ab7a5e1dffd4ff7109bf4fa54/README.md#L21-L25 which implies that the project is maintained again. So I am submitting the suggestion again.

Looking through the git history, it looks like bc4321d25db0b37f5e6264c58827d69264aa0260 made some major changes that converted a global `Prodnames` variable into an attribute of the `Grammar` class. This change missed one usage of `Prodnames` in the `Production` class which was then changed several years later to `self.Prodnames` in a813d9d76a4b67b0f6666c9933a59254a163d19b which satisfied flake8 at least at that time, even though `Production` has no `Prodnames` attribute. Since from the git history, `lr_item` has not been working for over ten years and is not referenced elsewhere in the project, this PR just removes it rather than trying to fix it.