### PR TITLE
Fix invalid escape sequence SyntaxWarning for '\#'

### DIFF
--- a/tests/testlex.py
+++ b/tests/testlex.py
@@ -190,7 +190,7 @@ class LexErrorWarningTests(unittest.TestCase):
                    "Make sure '#' in rule 't_POUND' is escaped with '\\#'\n")
         else:
             msg = ("Invalid regular expression for rule 't_POUND'. missing ), unterminated subpattern at position 0\n"
-                   "ERROR: Make sure '#' in rule 't_POUND' is escaped with '\#'")
+                   r"ERROR: Make sure '#' in rule 't_POUND' is escaped with '\#'")
         self.assertTrue(check_expected(result,
                                     msg,
                                     contains=True), result)


### PR DESCRIPTION
In the test file `testlex.py`, at line 193, on newer Python versions (3.12+), a SyntaxWarning is emitted when an invalid escape sequence is encountered, just like this:

```shell
ply/tests/testlex.py:193: SyntaxWarning: invalid escape sequence '\#'
  "ERROR: Make sure '#' in rule 't_POUND' is escaped with '\#'")
```

This PR changes the line to use a raw string for this. Raw strings were supported even in Python 2.7, so there is no problem here. See https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals