### PR TITLE
Guard unittest.main() invocation when test files are imported

### DIFF
--- a/tests/testlex.py
+++ b/tests/testlex.py
@@ -398,4 +398,5 @@ class LexRunTests(unittest.TestCase):
 
 
 
-unittest.main()
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testyacc.py
+++ b/tests/testyacc.py
@@ -400,4 +400,5 @@ class YaccErrorWarningTests(unittest.TestCase):
                                     "Precedence rule 'left' defined for unknown symbol '/'\n"
                                     ))
 
-unittest.main()
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR simply adds a `if __name__ == "__main__":` guard to the `unittest.main()` call at the end of the two test files, `tests/testlex.py` and `tests/testyacc.py`.

This change happens to follow the pattern of the basic example in unittest's docs: https://docs.python.org/3/library/unittest.html#basic-example

With this, this allows to run the test suite normally with the included makefile, as well as with pytest, that can run unittest tests without any changes.