### PR TITLE
Update .gitignore for current code layout and venv usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ __pycache__
 *~
 /dist
 /build
-/*.egg-info
+*.egg-info
+.venv


### PR DESCRIPTION
The .gitignore has not been updated since the code layout has been changed a couple of years ago. For example, the pattern for .egg-info assumed the code was in `ply/`, and now is in `src/ply/`. In the same time frame, the makefile was tuned to create a venv, but wasn't ignored in the .gitignore.

This PR addresses these two points, by ignoring `*.egg-info` in any subfolder, and also ignoring the .venv folder used.