### PR TITLE
Fix testyacc.py to work with Python 3.15

### DIFF
--- a/tests/testyacc.py
+++ b/tests/testyacc.py
@@ -21,7 +21,10 @@ def make_pymodule_path(filename):
     file = os.path.basename(filename)
     mod, ext = os.path.splitext(file)
 
-    if sys.hexversion >= 0x3040000:
+    if sys.hexversion >= 0x3050000:
+        import importlib.util
+        fullpath = importlib.util.cache_from_source(filename)
+    elif sys.hexversion >= 0x3040000:
         import importlib.util
         fullpath = importlib.util.cache_from_source(filename, ext=='.pyc')
     elif sys.hexversion >= 0x3020000:


### PR DESCRIPTION
cache_from_source(), from importlib.util, is now strict about enforcing only valid args in Python 3.15. This is appropriately conditionalized in testlex.py, but not in testyacc.py.

Note: I did not add support for the optional optimization parameter in testyacc.py, because I don't think it matters too much here, but it would be straightforward to do so if I'm wrong.